### PR TITLE
イシュー3、チーム情報操作について権限による制限を追加

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -1,4 +1,6 @@
 class AssignsController < ApplicationController
+  include TeamHelper
+
   before_action :authenticate_user!
 
   def create
@@ -30,20 +32,24 @@ class AssignsController < ApplicationController
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
+
+    elsif not has_fired_authority(assign.team_id,assigned_user.id)
+      '画面操作者に権限がないため、削除できませんでした。'
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
+
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,8 @@
 class TeamsController < ApplicationController
+  include TeamHelper
+
   before_action :authenticate_user!
+  before_action :chk_edit_authority, only: %i[edit update]
   before_action :set_team, only: %i[show edit update destroy]
 
   def index
@@ -30,6 +33,7 @@ class TeamsController < ApplicationController
   end
 
   def update
+
     if @team.update(team_params)
       redirect_to @team, notice: 'チーム更新に成功しました！'
     else
@@ -51,6 +55,12 @@ class TeamsController < ApplicationController
 
   def set_team
     @team = Team.friendly.find(params[:id])
+  end
+
+  def chk_edit_authority
+    if not has_edit_authority_team(Team.friendly.find(params[:id]).id)
+      redirect_to team_path(params[:id]), notice: '権限がない処理です。'
+    end
   end
 
   def team_params

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -2,4 +2,36 @@ module TeamHelper
   def default_img(image)
     image.presence || 'default.jpg'
   end
+
+  def has_edit_authority_team(team_id)
+
+    if user_signed_in? and team_id.present?
+
+      #現在のユーザーが[チームのオーナーid]ならTを返す
+      if current_user.id == Team.find(team_id).owner_id
+        return true
+      end
+
+    end
+
+    return false
+  end
+
+    def has_fired_authority(team_id,user_id)
+      
+      if user_signed_in? and team_id.present? and user_id.present?
+
+        #引数として持ってきたidからチームを取得
+        team=Team.find(team_id)
+
+        #現在のユーザーが[チームのオーナー]か[やめさせようとしているユーザー自身]ならTを返す
+        if current_user.id == team.owner_id || current_user.id == user_id
+          return true
+        end
+
+      end
+
+      return false
+    end
+
 end

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -27,6 +27,10 @@
 
   <div class="form-group">
     <%= form.hidden_field :owner_id, value: current_user.id %>
-    <%= form.submit '作成', class: 'btn btn-primary' %>
+
+    <% if (action_name == "new") || (has_edit_authority_team(@team.id)==true) %>
+      <%= form.submit '作成', class: 'btn btn-primary' %>
+    <% end %>
+
   </div>
 <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,11 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+
+            <% if has_edit_authority_team(@team.id) %>
+              <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
+
           </div>
 
           <div class="col-md-8">
@@ -41,7 +45,11 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      
+                      <% if has_fired_authority(@team.id,assign.user_id) %>
+                        <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
+
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
https://github.com/DiveintoCode-corp/diveintopost/issues/64
についての対応。

・『オーナーをチームから削除しようとした場合』については、従来どおり『ボタンを押した後のバリデーションで排除（【削除】ボタンを押すこと自体はできる）のままにしてあります。

・『自分自身を削除した後』の動作は、『それまで表示していた（＝現在はもうメンバーでない）チームのshow画面を表示』となっています。またこのshow画面で行う「ユーザーの、チームへの招待」はチームメンバーでなくても行えるようになっています。このため『自分をチームメンバーから削除』したあとで『自分や他の人間をそのチームに招待』できてしまっていますが、その点については本イシューの範囲外として修正していません。