### PR TITLE
fix_指摘事項の修正、その一（articleおよびcommentについて

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,28 +4,48 @@ class CommentsController < ApplicationController
     @comment = @article.comments.build(comment_params)
     @comment.user_id = current_user.id
     respond_to do |format|
-      if @comment.save!
+      if @comment.save
+      # if @comment.save!
+
         format.js { render :index }
       else
-        format.html { redirect_to article_path(@article), notice: '投稿できませんでした...' }
+        format.js { render :form }
+        # format.html { redirect_to article_path(@article), notice: '投稿できませんでした...' }
       end
     end
   end
 
   def edit
+
     @comment = Comment.find(params[:id])
+
   end
 
   def update
     @comment = Comment.find(params[:id])
     @article = @comment.article
-    redirect_to article_path(@article) if @comment.update(comment_params)
+
+    if @comment.update(comment_params)
+      redirect_to article_path(@article)
+    else
+
+      flash[:danger] = @comment.errors.full_messages
+      redirect_to edit_comment_path(@comment)
+    end
+    # redirect_to article_path(@article) if @comment.update(comment_params)
   end
 
   def destroy
+    
     @comment = Comment.find(params[:id])
+    @article = @comment.article
     if @comment.destroy
       respond_to do |format|
+
+        #form再表示用に、@commentを再セット
+        @comment = @article.comments.build
+        # @comment = @article.comments.build
+
         format.js { render :index }
       end
     end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -18,12 +18,12 @@
 
   <div class="form-group">
     <%= form.label :title %>
-    <%= form.text_field :title, placeholder: '記事タイトルを入力してください', class: 'form-control' %>
+    <%= form.text_field :title, placeholder: '記事タイトルを入力してください', class: 'form-control',maxlength: 100 %>
   </div>
 
   <div class="form-group">
     <%= form.label :content %>
-    <%= form.text_area :content, placeholder: '内容を入力してください', class: 'form-control', rows: 10 %>
+    <%= form.text_area :content, placeholder: '内容を入力してください', class: 'form-control', rows: 10,maxlength: 1000 %>
   </div>
 
   <div class="form-group">

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -14,6 +14,8 @@
     </div>
   <% end %>
 
+  <%= render 'layouts/show_danger_msg' %>
+
   <div class="form-group">
     <%= form.label :title %>
     <%= form.text_field :title, placeholder: '記事タイトルを入力してください', class: 'form-control' %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,5 +1,5 @@
-<p id="notice"><%= notice %></p>
 
+<p id="notice"><%= notice %></p>
 <div class="row">
   <div class="col-md-12">
     <div class="card">
@@ -25,8 +25,10 @@
       </div>
 
       <p>コメント投稿</p>
-      <!-- コメント入力欄をarticleの詳細ページに表示するためのrender -->
-      <%= render partial: 'comments/form', locals: { comment: @comment, article: @article } %>
+      <div id="comments_form">
+        <!-- コメント入力欄をarticleの詳細ページに表示するためのrender -->
+        <%= render partial: 'comments/form', locals: { comment: @comment, article: @article } %>
+      </div>
 
       <!-- /.card-body -->
     </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="field">
-    <%= form.text_area :content, class: "comment_input" %>
+    <%= form.text_area :content, class: "comment_input",maxlength: 10000  %>
   </div>
 
   <div class="actions">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,3 +1,4 @@
+
 <%= form_with(model: [article, comment]) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -6,7 +6,7 @@
 
 
   <div class="field">
-    <%= form.text_area :content, class: "comment_input" %>
+    <%= form.text_area :content, class: "comment_input",maxlength: 10000   %>
   </div>
 
   <div class="actions">

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,6 +1,10 @@
 
 <br><br><br>
 <%= form_with(model: @comment, local: true) do |form| %>
+
+<%= render 'layouts/show_danger_msg' %>
+
+
   <div class="field">
     <%= form.text_area :content, class: "comment_input" %>
   </div>

--- a/app/views/comments/form.js.erb
+++ b/app/views/comments/form.js.erb
@@ -1,0 +1,2 @@
+$("#comments_form").html("<%= j(render 'comments/form', { comment: @comment, article: @article }) %>")
+// $("textarea").val('')

--- a/app/views/comments/index.js.erb
+++ b/app/views/comments/index.js.erb
@@ -1,2 +1,5 @@
 $("#comments_area").html("<%= j(render 'comments/index', { comments: @comment.article.comments, article: @comment.article }) %>")
+
+$("#comments_form").html("<%= j(render 'comments/form', { comment: @article.comments.build, article: @article }) %>")
+
 $("textarea").val('')

--- a/app/views/layouts/_show_danger_msg.html.erb
+++ b/app/views/layouts/_show_danger_msg.html.erb
@@ -1,0 +1,15 @@
+
+  <% if (flash[:danger].present? and flash[:danger].any?) %>
+    <div class="alert alert-danger alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+      <h5>
+        <i class="icon fa fa-ban"></i>
+        <%= pluralize(flash[:danger].count, "error") %> prohibited this team from being saved:
+      </h5>
+      <ul>
+        <% flash[:danger].each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>


### PR DESCRIPTION
課題提出時に戴いた指摘（
https://client.diveintocode.jp/submissions/15557
の19/05/12 14:01
）のうち、
・Articleを空でcreateするとアプリがおちます。
・Articleにコメントをつけそれを編集するときに空で更新するとエラーメッセージの表示なくボタンがdisableのままです。
・Article commentは長い文字列や空を送ると、アラート無しで何も起きないので、せめてアラート表示しましょう。
を修正。