### PR TITLE
fix_指摘事項の修正、その二（アジェンダのタイトルについて

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -21,7 +21,12 @@ class AgendasController < ApplicationController
     if current_user.save && @agenda.save
       redirect_to dashboard_url, notice: 'アジェンダ作成に成功しました！'
     else
-      render :new
+
+      #入力情報をセッション、エラー情報をフラッシュに保存して
+      flash[:danger] = @agenda.errors.full_messages
+      redirect_to dashboard_url
+      # render :new
+
     end
   end
 

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -1,4 +1,5 @@
 class Agenda < ApplicationRecord
+  validates :title, length: { minimum: 1, maximum: 20 }
   belongs_to :team
   belongs_to :user
   has_many :articles, dependent: :destroy

--- a/app/views/agendas/_form.html.erb
+++ b/app/views/agendas/_form.html.erb
@@ -1,3 +1,7 @@
+<h1>開発用メモ：このビューはどこからも呼び出されていない模様。確認が取れ次第、削除する。</h1>
+<h1>なおこのビューが想定している「agendaのediot画面」も、現状ではどこからも遷移していない。</h1>
+<h1>エラーの原因となりかねないため、「/agendas/:id/edit(.:format)」へのルーティングは先に排除した。</h1>
+
 <%= form_with(model: @agenda, local: true, url: choose_new_or_edit) do |form| %>
   <% if @agenda.errors.any? %>
     <div id="error_explanation">

--- a/app/views/agendas/new.html.erb
+++ b/app/views/agendas/new.html.erb
@@ -1,26 +1,30 @@
 <h1>New Agenda</h1>
-<%= form_with(model: [@team, @agenda], local: true) do |form| %>
-  <% if @agenda.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@agenda.errors.count, "error") %> prohibited this agenda from being saved:</h2>
+<h4>アジェンダは、</h4>
+<h2>←←←</h2>
+<h4>の「アジェンダ作成」で作成してください。</h4>
 
-      <ul>
-      <% @agenda.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-  <div>
-    <%= form.text_field :title %>
-  </div>
-  <div>
-    <%= form.text_area :description %>
-  </div>
+<%# <%= form_with(model: [@team, @agenda], local: true) do |form| %><%# %>
+  <%# <% if @agenda.errors.any? %><%# %>
+    <!-- <div id="error_explanation"> -->
+      <!-- <h2><%#= pluralize(@agenda.errors.count, "error") %> prohibited this agenda from being saved:</h2> -->
 
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
+      <!-- <ul> -->
+      <%# <% @agenda.errors.full_messages.each do |message| %><%# %>
+        <%# <!-- <li><%= message %><%#</li> --> %>
+      <%# <% end %><%# %>
+      <!-- </ul> -->
+    <!-- </div> -->
+  <%# <% end %><%# %>
+  <!-- <div> -->
+    <%# <%= form.text_field :title %><%# %>
+  <!-- </div> -->
+  <!-- <div> -->
+    <%# <%= form.text_area :description %><%# %>
+  <!-- </div> -->
 
-<%= link_to 'Back', team_agendas_path %>
+  <!-- <div class="actions"> -->
+    <%# <%= form.submit %><%# %>
+  <!-- </div> -->
+<%# <% end %><%# %>
+
+<%# <%= link_to 'Back', team_agendas_path %><%# %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -17,7 +17,7 @@
         <a href="#" class="d-block mb-1">アジェンダ作成</a>
         <%= form_with model: :agenda, scope: :post, url: team_agendas_path(@working_team), local: true do |form| %>
           <div class="input-group input-group-sm">
-            <%= text_field_tag :title, '', { class: 'form-control', placeholder: 'タイトル入力' } %>
+            <%= text_field_tag :title, '', { class: 'form-control', placeholder: 'タイトル入力',maxlength: 20}  %>
             <span class="input-group-append">
               <button type="submit" class="btn btn-info btn-flat">作成</button>
             </span>

--- a/app/views/teams/dashboard.html.erb
+++ b/app/views/teams/dashboard.html.erb
@@ -1,5 +1,7 @@
 <p id="notice"><%= notice %></p>
 
+<%= render 'layouts/show_danger_msg' %>
+
 <div class="row mt-3">
   <div class="col-md-8">
     <div class="card">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,14 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
-    resources :agendas, shallow: true do
+
+
+    resources :agendas, shallow: true, except: [:edit] do
+    # resources :agendas, shallow: true do
+
       resources :articles do
         resources :comments
       end


### PR DESCRIPTION
課題提出時に戴いた指摘（
https://client.diveintocode.jp/submissions/15557
の19/05/12 14:01
）のうち、
・Agendaが空で無限に作れます
・Agenda作成の時titleを長くすると、アプリが落ちます。
を修正。
また現在使われていないことを確認し、【Agenda専用の新規登録，更新画面】を無効化
（新規登録画面は画面表示文章で「sidebarでの登録」に誘導。そもそも遷移元が無い更新画面はルーティング自体を削除（ビューは念の為、まだ残してあります））。